### PR TITLE
Update mtp packet buffer

### DIFF
--- a/media/mtp/MtpPacket.cpp
+++ b/media/mtp/MtpPacket.cpp
@@ -168,8 +168,10 @@ void MtpPacket::setParameter(int index, uint32_t value) {
         return;
     }
     int offset = MTP_CONTAINER_PARAMETER_OFFSET + (index - 1) * sizeof(uint32_t);
-    if (mPacketSize < offset + sizeof(uint32_t))
+    if (mPacketSize < offset + sizeof(uint32_t)) {
         mPacketSize = offset + sizeof(uint32_t);
+        allocate(mPacketSize);
+    }
     putUInt32(offset, value);
 }
 


### PR DESCRIPTION
Currently, the buffer size is not changed when the packet size is increased. Ideally, the buffer size should be larger than the packet size. In our case, when the packet size is increased, we must reallocate the buffer of MTP packet.

Bug: 300007708
Test: build and flash the device. Check MTP works
Test: run fuzzer locally
(cherry picked from commit e1494a2d8e7eee25d7ea5469be43740e97294c99) (cherry picked from https://googleplex-android-review.googlesource.com/q/commit:5c0f99beb6fa5ff920caf5b0d06aaebc8e9eab24\) (cherry picked from https://googleplex-android-review.googlesource.com/q/commit:38852806102bb7e9d46f4b0de8a3b4918d625ad4\) Merged-In: I98398a9e15962e6d5f08445ee7b17f5d61a3a528 Change-Id: I98398a9e15962e6d5f08445ee7b17f5d61a3a528